### PR TITLE
Bugfix/terminates on expected error

### DIFF
--- a/synse_loadgen/app.py
+++ b/synse_loadgen/app.py
@@ -320,7 +320,7 @@ async def on_write_async(
                     with expect_error('write_async', client):
                         _ = await client.write_async(
                             device=random.choice(leds),
-                            payload={'action': 'color', 'data': 'ff33aa'},
+                            payload={'action': 'color', 'data': 'not a hex color'},
                         )
                 return
 
@@ -364,7 +364,7 @@ async def on_write_sync(
                     with expect_error('write_sync', client):
                         _ = await client.write_sync(
                             device=random.choice(leds),
-                            payload={'action': 'color', 'data': 'ff33aa'},
+                            payload={'action': 'color', 'data': 'not a hex color'},
                         )
                 return
 


### PR DESCRIPTION
This PR:
- fixes a bug where expected errors were not being trapped and were propagating up, terminating the service.
- fixes a bug where a test for invalid write data was using valid write data
- fixes a bug/adds a feature where loadgen may terminate on startup if synse server wasn't immediately available to connect to.


fixes #4