### PR TITLE
ci: add stage for automated helm chart update

### DIFF
--- a/.chartreleaser.yml
+++ b/.chartreleaser.yml
@@ -1,0 +1,22 @@
+# .chartreleaser.yaml is the configuration file for chart-releaser, a CI tool
+# to update Helm Charts on application release. See the documentation at
+# https://github.com/edaniszewski/chart-releaser
+
+version: v1
+chart:
+  name: synse-loadgen
+  path: synse-loadgen
+  repo: github.com/vapor-ware/synse-charts
+commit:
+  author:
+    name: vio-bot
+    email: 'marco+viogh@vapor.io'
+extras:
+- path: synse-loadgen/README.md
+  updates:
+  - search: '\| `image\.tag` \| The tag of the image to use\. \| `[0-9a-zA-Z.-]*` \|'
+    replace: '| `image.tag` | The tag of the image to use. | `{{ .App.NewVersion }}` |'
+- path: synse-loadgen/values.yaml
+  updates:
+  - search: 'tag: "[0-9a-zA-Z.-]*"'
+    replace: 'tag: "{{ .App.NewVersion }}"'

--- a/.jenkins
+++ b/.jenkins
@@ -83,5 +83,21 @@ pipeline {
       }
     }
 
+    stage('Updating Helm Chart') {
+      when {
+        buildingTag()
+      }
+      agent {
+        // Label "deploy" maps to a vaporio/deployment-tools container
+        label 'deploy'
+      }
+      environment {
+        GITHUB_TOKEN = credentials('vio-bot-gh-token')
+      }
+      steps {
+        sh 'chart-releaser update --diff --debug'
+      }
+    }
+
   }
 }


### PR DESCRIPTION
This PR:
- adds a config + jenkins stage for chart-releaser, a tool to help automate helm chart updates on new app version release.

The tool is still real new and I still need to figure out how to get everything set up in CI properly for it, but figured I'd use this repo as a guinea pig to try and get it working. Once that all looks okay, we could start adding similar config to other repos