### PR TITLE
update: fix cli arguments for isort>=5.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ exclude = bin/,.tox/,examples/,.git
 ignore = W605,F401,E501
 
 [isort]
-not_skip = __init__.py
 default_section = THIRDPARTY
 known_first_party = synse_loadgen,tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,19 +9,19 @@ commands =
 
 [testenv:fmt]
 deps =
-    isort
+    isort>=5.0.0
     autopep8
 commands =
-    isort --recursive --atomic {posargs:synse_loadgen}
+    isort --atomic {posargs:synse_loadgen}
     autopep8 --recursive --in-place {toxinidir}
 
 [testenv:lint]
 deps =
-    isort
+    isort>=5.0.0
     flake8
     twine>=1.12.0
 commands =
-    isort -rc -c --diff {posargs:synse_loadgen}
+    isort --check --diff {posargs:synse_loadgen}
     flake8 --show-source --statistics {posargs:synse_loadgen}
     python setup.py sdist bdist_wheel
     twine check dist/*


### PR DESCRIPTION
This  PR:
- updates command line options for new isort version

fixes #8